### PR TITLE
Fix uninstaller

### DIFF
--- a/alinks.install
+++ b/alinks.install
@@ -6,8 +6,8 @@
  */
 
 function alinks_uninstall() {
-  \Drupal::config('alinks.settings')->clear('node_types')->save();
-  \Drupal::config('alinks.settings')->clear('limit')->save();
+  \Drupal::configFactory()->getEditable('alinks.settings')->clear('node_types')->save();
+  \Drupal::configFactory()->getEditable('alinks.settings')->clear('limit')->save();
 }
 
 /**


### PR DESCRIPTION
Could not uninstall as would fail with error: "Can not clear node_types key in immutable configuration alinks.settings."
This fixes the issue. See: https://www.drupal.org/node/2407153
