### PR TITLE
make xpathSelector configurable / basic views integration

### DIFF
--- a/config/install/alinks.settings.yml
+++ b/config/install/alinks.settings.yml
@@ -3,3 +3,4 @@ displays:
     entity_type: node
     entity_bundle: article
     entity_display: full
+xpathSelector: '//*//p//text()[not(ancestor::a) and not(ancestor::script) and not(ancestor::*[@data-alink-ignore])]'

--- a/src/AlinkPostRenderer.php
+++ b/src/AlinkPostRenderer.php
@@ -188,7 +188,7 @@ class AlinkPostRenderer {
   }
 
   public static function postRender($content, $context) {
-    $selector = "//*//p//text()[not(ancestor::a) and not(ancestor::script) and not(ancestor::*[@data-alink-ignore])]";
+    $selector = \Drupal::config('alinks.settings')->get('xpathSelector');
     $renderer = new static($content, $context, $selector);
     return $renderer->replace();
   }

--- a/src/Entity/Keyword.php
+++ b/src/Entity/Keyword.php
@@ -20,6 +20,7 @@ use Drupal\user\UserInterface;
  *   label = @Translation("Keyword"),
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "views_data" = "Drupal\alinks\Entity\KeywordViewsData",
  *     "list_builder" = "Drupal\alinks\KeywordListBuilder",
  *     "translation" = "Drupal\content_translation\ContentTranslationHandler",
  *     "form" = {

--- a/src/Entity/KeywordViewsData.php
+++ b/src/Entity/KeywordViewsData.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\alinks\Entity;
+
+use Drupal\views\EntityViewsData;
+use Drupal\views\EntityViewsDataInterface;
+
+/**
+ * Provides Views data for keyword entities.
+ */
+class KeywordViewsData extends EntityViewsData implements EntityViewsDataInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public function getViewsData() {
+    $data = parent::getViewsData();
+
+    $data['alink_keyword']['table']['base'] = [
+      'field' => 'id',
+      'title' => $this->t('Keyword entity'),
+      'help' => $this->t('Keyword entity ID.'),
+    ];
+
+    $data['alink_keyword_field_data']['table']['join'] = array(
+      'alink_keyword' => array(
+        'field' => 'id',
+        'left_field' => 'id',
+      ),
+    );
+
+    return $data;
+  }
+
+}


### PR DESCRIPTION
In some cases the default xpathSelector in postRender is not enough to process the html DOM. We should make this setting configurable. 
This PR is just adding this as a config setting while installing. Looking further we could provide a settings form also.